### PR TITLE
Feature/waypoint visualization

### DIFF
--- a/ros/.gitignore
+++ b/ros/.gitignore
@@ -1,0 +1,8 @@
+# ROS
+build/
+devel/
+# Clion
+.idea/
+cmake-build-debug/
+# Vim
+*.swp

--- a/ros/launch/visualization.launch
+++ b/ros/launch/visualization.launch
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<launch>
+    <!-- rviz for waypoint visualization -->
+    <node pkg="rviz" type="rviz" name="rviz" args="-d $(find waypoint_loader)/rviz/waypoints.rviz"/>
+</launch>

--- a/ros/src/waypoint_loader/rviz/waypoints.rviz
+++ b/ros/src/waypoint_loader/rviz/waypoints.rviz
@@ -1,0 +1,154 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 81
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Grid1/Offset1
+        - /BaseWaypoints1/Namespaces1
+      Splitter Ratio: 0.5
+    Tree Height: 1194
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679016
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 100
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.0299999993
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 909.799988
+        Y: 1128.69995
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 50
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz/Axes
+      Enabled: true
+      Length: 100
+      Name: AxesWorld
+      Radius: 5
+      Reference Frame: world
+      Value: true
+    - Alpha: 1
+      Axes Length: 1
+      Axes Radius: 0.100000001
+      Class: rviz/Pose
+      Color: 255; 25; 0
+      Enabled: true
+      Head Length: 2
+      Head Radius: 5
+      Name: CurrentPose
+      Shaft Length: 10
+      Shaft Radius: 3
+      Shape: Arrow
+      Topic: /current_pose
+      Unreliable: false
+      Value: true
+    - Class: rviz/Image
+      Enabled: true
+      Image Topic: /image_color
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: TrafficLightImage
+      Normalize Range: true
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+    - Class: rviz/MarkerArray
+      Enabled: true
+      Marker Topic: /base_waypoints_markers
+      Name: BaseWaypoints
+      Namespaces:
+        "": true
+      Queue Size: 10
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Angle: 0
+      Class: rviz/TopDownOrtho
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.0599999987
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.00999999978
+      Scale: 0.829463005
+      Target Frame: base_link
+      Value: TopDownOrtho (rviz)
+      X: 1330.15002
+      Y: 2064.22241
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 2087
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000002840000074afc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000007000fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000005d00000551000000f800fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000220054007200610066006600690063004c00690067006800740049006d00610067006501000005b8000001ef0000001f00ffffff00000001000001270000074afc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000005d0000074a000000d600fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000f000000004efc0100000002fb0000000800540069006d0065010000000000000f000000035400fffffffb0000000800540069006d0065010000000000000450000000000000000000000b410000074a00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  TrafficLightImage:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 3840
+  X: 0
+  Y: 49

--- a/ros/src/waypoint_loader/rviz/waypoints.rviz
+++ b/ros/src/waypoint_loader/rviz/waypoints.rviz
@@ -129,8 +129,8 @@ Visualization Manager:
       Scale: 0.829463005
       Target Frame: base_link
       Value: TopDownOrtho (rviz)
-      X: 1330.15002
-      Y: 2064.22241
+      X: 315.035278
+      Y: 834.513062
     Saved: ~
 Window Geometry:
   Displays:


### PR DESCRIPTION
The `waypoint_loader.py` now publishes a marker array with the base waypoints.

**How to test (in directory `ros/launch`)**:
`roslaunch visualization.launch` and in another terminal `roslaunch styx.launch` (optionally run the simulation with activated camera).

Rviz should show the base waypoints in grey, the current pose in red and the camera image.