### PR TITLE
Additional output and adaptation for testing detector

### DIFF
--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -60,8 +60,10 @@ class TLClassifier(object):
 
         max_scores = [j for (i,j) in zip(scores, classes) if i >= self.confidence_cutoff]
         if max_scores is None or not max_scores:
+            print "color: unknown"
             return TrafficLight.UNKNOWN
         else:
+            print "color:", int(max_scores[0])
             return self.get_tl_color(int(max_scores[0]))
     
     def get_tl_color(self, color_class):

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -137,6 +137,7 @@ class TLDetector(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
+        print "processing..."
         closest_light = None
         line_wp_idx = None
 
@@ -158,7 +159,7 @@ class TLDetector(object):
                     closest_light = light
                     line_wp_idx = temp_wp_idx
 
-        if closest_light:
+        if True: # apparently the stop light positions are not contained in the bag
             state = self.get_light_state(closest_light)
             return line_wp_idx, state
 


### PR DESCRIPTION
Do not merge this, only for testing!

Related to #24.
Usage, in different terminals:
- `rosbag play -l traffic_light_training.bag`
- `roslaunch visualization.launch # for the camera image`
- `roslaunch site.launch`

The `site.launch` should give output like the following:
```
color: 2
processing...
 color: 2
processing...
color: unknown
 color: 2
processing...
processing...
color: unknown
color: 2
processing...
processing...
color: unknown
processing...
color: 2
```

For me there seem to be some problems:
- the only results are 2 (red) and 3 (dunno, esp. in the beginning)
- there is not always a detection when a light is in the image